### PR TITLE
update 'gtfs-realtime-bindings' package version to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "csv-parser": "^2.0.0",
     "duplexify": "^4.0.0",
     "end-of-stream": "github:isaacs/end-of-stream#custom-stream-premature-close-fix",
-    "gtfs-realtime-bindings": "^0.0.4",
+    "gtfs-realtime-bindings": "^0.0.5",
     "lodash.pickby": "^4.6.0",
     "merge2": "^1.2.2",
     "parse-decimal-number": "^1.0.0",


### PR DESCRIPTION
npm audit reports that the current version of protobufjs, a dependency of gtfs-realtime-bindings, contains a security vulnerability.
This PR updates the version of gtfs-realtime-bindings in package.json from 0.0.4 to 0.0.5, which resolves the vulnerability.